### PR TITLE
chore: fix-name-conflict

### DIFF
--- a/revit-mcp-commandset/Models/Common/ViewInfo.cs
+++ b/revit-mcp-commandset/Models/Common/ViewInfo.cs
@@ -1,6 +1,6 @@
 ﻿namespace RevitMCPCommandSet.Models.Common
 {
-    public class ViewInfo
+    public class CurrentViewInfo
     {
         public long Id { get; set; }
         public string UniqueId { get; set; }

--- a/revit-mcp-commandset/Services/GetCurrentViewInfoEventHandler.cs
+++ b/revit-mcp-commandset/Services/GetCurrentViewInfoEventHandler.cs
@@ -7,7 +7,7 @@ namespace RevitMCPCommandSet.Services
     public class GetCurrentViewInfoEventHandler : IExternalEventHandler, IWaitableExternalEventHandler
     {
         // 执行结果
-        public ViewInfo ResultInfo { get; private set; }
+        public CurrentViewInfo ResultInfo { get; private set; }
 
         // 状态同步对象
         public bool TaskCompleted { get; private set; }
@@ -27,7 +27,7 @@ namespace RevitMCPCommandSet.Services
                 var doc = uiDoc.Document;
                 var activeView = doc.ActiveView;
 
-                ResultInfo = new ViewInfo
+                ResultInfo = new CurrentViewInfo
                 {
 #if REVIT2024_OR_GREATER
                     Id = (int)activeView.Id.Value,


### PR DESCRIPTION
@jmcouffin Could you please review this PR?
This PR addresses the naming conflict issue reported in #5.

## Changes
- Renamed `ViewInfo` class to `CurrentViewInfo` in `Models/Common/ViewInfo.cs`
- Updated all references to use the new `CurrentViewInfo` class name
- Resolved IDE "Go to Definition" ambiguity between the nested `ViewInfo` class in `AIElementFilterEventHandler` and the model class

## Problem Solved
Previously, there were two classes with the same name `ViewInfo` in different namespaces, which caused confusion during development. The IDE's "Go to Definition" was resolving to the nested class instead of the intended model class.

This change clarifies the naming and eliminates potential conflicts for future contributors.

Fixes #5
